### PR TITLE
fix: make `useContext` API available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export default compositionApiModule
 export const meta = require('../package.json')
 
 export { useFetch } from './fetch'
-export { withContext } from './context'
+export { withContext, useContext } from './context'
 export { ssrRef, onServerPrefetch, setSSRContext } from './ssr-ref'
 export { useHead } from './meta'
 


### PR DESCRIPTION
Somehow the `useContext` API seems not available even though it appears & is mentioned on README.

Please do not mind closing this PR if there's any particular reason not to make it available until the certain future point.