### PR TITLE
fix: 🐛 Support reactive useMeta in layouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     {
       "name": "Daniel Roe <daniel@roe.dev>",
       "url": "https://github.com/danielroe"
+    },
+    {
+      "name": "Jacob Andersson <jacob@sigbit.se>",
+      "url": "https://github.com/miii"
     }
   ],
   "keywords": [


### PR DESCRIPTION
This PR uses `Vue.observable` instead of `reactive` to create meta refs to enable usage of `useMeta()` in layouts. This will also refresh vue-meta automatically if the state is updated. Since the observable API is used, Vue 2.6.0+ is required. Let me know if there are any issues with the suggested change.

✅ Closes: #64