### PR TITLE
create static reference to route in useContext

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -56,11 +56,11 @@ export const useContext = (): UseContextReturn => {
       ...vm[globalNuxt].context,
       route: ref(vm.$route),
       query: computed(() => _context.route.value.query),
-      from: computed(() => _context.route.value.from),
-      params: computed(() => _context.route.value.query.params),
+      from: computed(() => _context.route.value.redirectedFrom),
+      params: computed(() => _context.route.value.params),
     }
   } else {
-    const {route, query, from, params, ...rest} = vm[globalNuxt].context
+    const { route, query, from, params, ...rest } = vm[globalNuxt].context
     Object.assign(_context, rest)
     _context.route.value = vm.$route
   }


### PR DESCRIPTION
Currently, `useContext` creates a new reference to the route and its components on every call, which defeats the ability to watch the route. This PR creates a static object, including the route references, and just updates the route value in the reference when called.