### PR TITLE
fix: use `Promise.resolve()` to cover all possible promise cases

### DIFF
--- a/src/async.ts
+++ b/src/async.ts
@@ -43,19 +43,15 @@ export const useAsync = <T>(
       process.client &&
       window[globalNuxt]?.context.isHMR)
   ) {
-    const p = cb()
+    const p = Promise.resolve(cb())
 
-    if (p instanceof Promise) {
-      if (process.server) {
-        onServerPrefetch(async () => {
-          _ref.value = await p
-        })
-      } else {
-        // eslint-disable-next-line
-        p.then(res => (_ref.value = res))
-      }
+    if (process.server) {
+      onServerPrefetch(async () => {
+        _ref.value = await p
+      })
     } else {
-      _ref.value = p
+      // eslint-disable-next-line
+      p.then(res => (_ref.value = res))
     }
   }
 


### PR DESCRIPTION
Fixes #210. This will convert all callback given to useAsync to Promises. Ensures that if the callback is any sort of promise it will resolve properly. If the function is not a promise, Promise.resolve() shouldn't cause any issues.