### PR TITLE
fix(useasync): useAsync should be reexecuted on route change

### DIFF
--- a/docs/content/en/useAsync.md
+++ b/docs/content/en/useAsync.md
@@ -11,6 +11,8 @@ On the server, this helper will inline the result of the async call in your HTML
 
 However, if the call hasn't been carried out on SSR (such as if you have navigated to the page after initial load), it returns a `null` ref that is filled with the result of the async call when it resolves.
 
+If you load the page with SSR leave the page and return to the exact same route the function will not rerun! If the route changes in any way the function will rerun.
+
 ```ts
 import { defineComponent, useAsync, computed } from '@nuxtjs/composition-api'
 import axios from 'axios'

--- a/src/async.ts
+++ b/src/async.ts
@@ -4,6 +4,7 @@ import type { Ref } from '@vue/composition-api'
 import { globalNuxt } from './globals'
 import { ssrRef } from './ssr-ref'
 import { validateKey } from './utils'
+import { useContext } from './context'
 
 /**
  * You can create reactive values that depend on asynchronous calls with `useAsync`.
@@ -34,6 +35,9 @@ export const useAsync = <T>(
   key?: string | Ref<null>
 ): Ref<null | T> => {
   validateKey(key)
+
+  // ensure reexecution after route change
+  key += useContext().route.value.fullPath
 
   const _ref = isRef(key) ? key : ssrRef<T | null>(null, key)
 

--- a/src/async.ts
+++ b/src/async.ts
@@ -37,7 +37,7 @@ export const useAsync = <T>(
   validateKey(key)
 
   // ensure reexecution after route change
-  key += useContext().route.value.fullPath
+  if (!isRef(key)) key += useContext().route.value.fullPath
 
   const _ref = isRef(key) ? key : ssrRef<T | null>(null, key)
 

--- a/src/async.ts
+++ b/src/async.ts
@@ -11,6 +11,8 @@ import { useContext } from './context'
  * On the server, this helper will inline the result of the async call in your HTML and automatically inject them into your client code. Much like `asyncData`, it _won't_ re-run these async calls client-side.
  *
  * However, if the call hasn't been carried out on SSR (such as if you have navigated to the page after initial load), it returns a `null` ref that is filled with the result of the async call when it resolves.
+ * 
+ * If you load the page with SSR leave the page and return to the exact same route the function will not rerun! If the route changes in any way the function will rerun.
  *
  * **At the moment, `useAsync` is only suitable for one-offs, unless you provide your own unique key.**
  * @param cb The async function that will populate the ref this function returns.

--- a/test/e2e/ssr-refs.ts
+++ b/test/e2e/ssr-refs.ts
@@ -21,6 +21,7 @@ test('Shows data on ssr-loaded page', async t => {
   await t.click(Selector('a').withText('ssr refs'))
   await expectOnPage('ref-only SSR rendered')
   await expectOnPage('shallow-client')
+  await expectOnPage('on: client')
 })
 
 test('Shows appropriate data on client-loaded page', async t => {

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -34,7 +34,7 @@
     <h2>Links</h2>
     <ul>
       <li><nuxt-link to="/other">link forward</nuxt-link></li>
-      <li><nuxt-link to="/ssr-ref">ssr refs</nuxt-link></li>
+      <li><nuxt-link to="/ssr-ref?fromHome=true">ssr refs</nuxt-link></li>
       <li><nuxt-link to="/promise">promise</nuxt-link></li>
       <li><nuxt-link to="/context/a">context</nuxt-link></li>
       <li><nuxt-link to="/hooks">hooks</nuxt-link></li>


### PR DESCRIPTION
BREAKING CHANGE: useAsync now gets reexecuted when the component is used in a other route than first
load.

fix #171

## ToDos:
- [x] e2e tests