### PR TITLE
fix: remove `markReactive` export

### DIFF
--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -45,7 +45,6 @@ export {
   isReadonly,
   isRef,
   markRaw,
-  markReactive,
   nextTick,
   onActivated,
   onBeforeMount,


### PR DESCRIPTION
Fixes #238 

Looks like the only place in the codebase where `markReactive` was mentioned was in `entrypoint.ts` where it was just being exported from `@vue/composition-api`. All I have done here is to remove the export which seems to fix the issue for me.

I guess this could be a breaking change if someone was relying on importing `markReactive` from the package, but this is in line with `@vue/composition-api` so the change would need to be handled anyway.