### PR TITLE
refactor: expose the UseContextReturn interface

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -21,7 +21,7 @@ export const withContext = (callback: ContextCallback) => {
   callback(vm[globalNuxt].context)
 }
 
-interface UseContextReturn
+export interface UseContextReturn
   extends Omit<Context, 'route' | 'query' | 'from' | 'params'> {
   route: Ref<Route>
   query: Ref<Route['query']>


### PR DESCRIPTION
Do you guys see any problem on exposing the `UseContextReturn` interface?

I am a bit new in TypeScript but during a refactoring I ended up in the following scenario where I am creating a composable function to help me to wrap some code and make it reusable and to do so I would need to inject the nuxt context on it.

This is an example of the scenario which took me to open this PR.

`// layouts/default.vue`
```html
<script lang="ts">
import { defineComponent, useContext } from '@nuxtjs/composition-api'
import { useSystemBootstrap } from '~/composable/system-bootstrap'

export default defineComponent({
  name: 'LayoutsBusiness',
  setup(_, { root }: SetupContext) {
    const nuxtContext = useContext()
    const {
      bootAnalytics,
      ...
    } = useSystemBootstrap(nuxtContext)

    bootAnalytics()

    return {}
  },
})
</script>
```

`~/composable/system-bootstrap`
```typescript
import type { UseContextReturn } from '@nuxtjs/composition-api'

export const useSystemBootstrap = (context: UseContextReturn) => {
  const {
    app: { $analytics },
    ...
  } = context

  const bootAnalytics = () => {
    $analytics.releaseQueue()
    // plus a bunch of other things
  }

  ...
  return {
    bootAnalytics,
  }
}
```