### PR TITLE
feat: allow computed properties within `useMeta`

### DIFF
--- a/docs/content/en/useMeta.md
+++ b/docs/content/en/useMeta.md
@@ -8,7 +8,7 @@ fullscreen: True
 You can interact directly with [head properties](https://nuxtjs.org/api/pages-head/) in `setup` by means of the `useMeta()` helper.
 
 ```ts
-import { defineComponent, useMeta, computed } from '@nuxtjs/composition-api'
+import { defineComponent, useMeta, computed, ref } from '@nuxtjs/composition-api'
 
 export default defineComponent({
   // You need to define an empty head to activate this functionality
@@ -23,6 +23,10 @@ export default defineComponent({
 
     // ... or simply set some meta tags
     useMeta({ title: 'My page', ... })
+
+    // You can even pass a function to achieve a computed meta
+    const message = ref('')
+    useMeta(() => ({ title: message.value }))
   },
 })
 ```

--- a/test/e2e/meta.ts
+++ b/test/e2e/meta.ts
@@ -15,6 +15,9 @@ test('Shows correct title on server-loaded page', async t => {
   await t.click(Selector('button').withText('Change'))
   await t.expect(Selector('title').innerText).eql('mounted title - Changed')
 
+  await t.click(Selector('button').withText('Set'))
+  await t.expect(Selector('meta').getAttribute('content')).eql('new message')
+
   await t.click(Selector('a').withText('back'))
   await t.expect(Selector('title').innerText).eql('My fixture - fixture')
 })
@@ -30,4 +33,7 @@ test('Shows correct title on client-loaded page', async t => {
 
   await t.click(Selector('button').withText('Change'))
   await t.expect(Selector('title').innerText).eql('mounted title - Changed')
+
+  await t.click(Selector('button').withText('Set'))
+  await t.expect(Selector('meta').getAttribute('content')).eql('new message')
 })

--- a/test/fixture/pages/meta.vue
+++ b/test/fixture/pages/meta.vue
@@ -3,6 +3,7 @@
     <p>
       <code>title-{{ title }}</code>
       <button @click="changeTitleTemplate">Change title template</button>
+      <button @click="setMessage">Set message</button>
     </p>
   </blockquote>
 </template>
@@ -11,6 +12,7 @@
 import {
   defineComponent,
   useMeta,
+  ref,
   computed,
   onMounted,
 } from '@nuxtjs/composition-api'
@@ -23,6 +25,16 @@ export default defineComponent({
     title.value = 'oldSetTitle'
 
     const { title: newImport, bodyAttrs, titleTemplate } = useMeta()
+
+    const message = ref('')
+    const setMessage = () => (message.value = 'new message')
+    useMeta(() => ({
+      meta: [{
+        name: 'message',
+        content: message.value
+      }]
+    }))
+
     newImport.value = 'newSetTitle'
 
     onMounted(() => {
@@ -37,7 +49,7 @@ export default defineComponent({
       titleTemplate.value = `%s - Changed`
     }
 
-    return { title, changeTitleTemplate, titleTemplate }
+    return { title, changeTitleTemplate, titleTemplate, setMessage }
   },
 })
 </script>


### PR DESCRIPTION
**Usage**:
In addition to the existing usage for `useMeta`, this adds the possibility to pass a function which will effectively generate a computed head state and be merged with any other head values.
```
useMeta(() => ({ title: message.value }))
```

nuxt-community/typescript-template#225

closes #254

