### PR TITLE
fix: prevent `useMeta` from sharing state in ssr

### DIFF
--- a/src/meta.ts
+++ b/src/meta.ts
@@ -91,17 +91,17 @@ type ToRefs<T extends Record<string, any>> = {
 /**
  * `useMeta` lets you interact directly with [`head()` properties](https://nuxtjs.org/api/pages-head/) in `setup`. **Make sure you set `head: {}` in your component options.**
  * @example
- ```ts
- import { defineComponent, useMeta, computed } from '@nuxtjs/composition-api'
+    ```ts
+    import { defineComponent, useMeta, computed } from '@nuxtjs/composition-api'
 
- export default defineComponent({
+    export default defineComponent({
       head: {},
       setup() {
         const { title } = useMeta()
         title.value = 'My page'
       })
     })
- ```
+    ```
  * @param init Whatever defaults you want to set for `head` properties.
  */
 export const useMeta = <
@@ -121,9 +121,7 @@ export const useMeta = <
       'In order to enable `useMeta`, please make sure you include `head: {}` within your component definition, and you are using the `defineComponent` exported from @nuxtjs/composition-api.'
     )
 
-  function refreshMeta() {
-    vm!.$meta().refresh()
-  }
+  const refreshMeta = () => vm.$meta().refresh()
 
   if (!vm._computedHead) {
     const metaRefs = reactive(createEmptyMeta())

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -63,7 +63,6 @@ export function createEmptyMeta(): MetaInfoMapper<Required<MetaInfo>> {
 }
 
 type ComputedHead = Array<MetaInfo | Ref<MetaInfo>>
-type MetaRefs = ToRefs<ReturnType<typeof createEmptyMeta>>
 
 export const getHeadOptions = (options: { head: () => MetaInfo }) => {
   const head = function (this: {
@@ -105,7 +104,12 @@ type ToRefs<T extends Record<string, any>> = {
  ```
  * @param init Whatever defaults you want to set for `head` properties.
  */
-export const useMeta = <T extends MetaInfo>(init?: T | (() => T)) => {
+export const useMeta = <
+  T extends MetaInfo,
+  MetaRefs extends ToRefs<ReturnType<typeof createEmptyMeta> & T>
+>(
+  init?: T | (() => T)
+) => {
   const vm = getCurrentInstance() as ReturnType<typeof getCurrentInstance> & {
     _computedHead?: ComputedHead
     _metaRefs?: MetaRefs
@@ -140,5 +144,5 @@ export const useMeta = <T extends MetaInfo>(init?: T | (() => T)) => {
     }
   }
 
-  return vm._metaRefs
+  return vm._metaRefs!
 }

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -3,10 +3,14 @@ import {
   computed,
   getCurrentInstance,
   reactive,
+  ref,
   toRefs,
   watch,
   Ref,
   set,
+  isReactive,
+  isRef,
+  toRaw,
   UnwrapRef,
 } from '@vue/composition-api'
 
@@ -58,20 +62,27 @@ export function createEmptyMeta(): MetaInfoMapper<Required<MetaInfo>> {
   }
 }
 
-export const getHeadOptions = (options: {
-  head: () => Record<string, any> | Record<string, any>
-}) => {
-  const _head: ReactiveHead =
-    options.head instanceof Function
-      ? reactive<MetaInfo>({})
-      : reactive<MetaInfo>(options.head)
-  const _computedHead: Array<Ref<MetaInfo>> = []
-  const head =
-    options.head instanceof Function
-      ? () =>
-          defu(..._computedHead.map(val => val.value), _head, options.head())
-      : () => defu(..._computedHead.map(val => val.value), _head, {})
-  return { _head, _computedHead, head }
+type ComputedHead = Array<MetaInfo | Ref<MetaInfo>>
+type MetaRefs = ToRefs<ReturnType<typeof createEmptyMeta>>
+
+export const getHeadOptions = (options: { head: () => MetaInfo }) => {
+  const head = function (this: {
+    head?: MetaInfo | (() => MetaInfo)
+    _computedHead?: ComputedHead
+  }) {
+    const optionHead =
+      options.head instanceof Function ? options.head.call(this) : options.head
+
+    if (!this._computedHead) return optionHead
+
+    const computedHead = this._computedHead.map(h => {
+      if (isReactive(h)) return toRaw(h)
+      if (isRef(h)) return h.value
+    })
+    return defu(...computedHead.reverse(), optionHead)
+  }
+
+  return { head }
 }
 
 type ToRefs<T extends Record<string, any>> = {
@@ -81,45 +92,53 @@ type ToRefs<T extends Record<string, any>> = {
 /**
  * `useMeta` lets you interact directly with [`head()` properties](https://nuxtjs.org/api/pages-head/) in `setup`. **Make sure you set `head: {}` in your component options.**
  * @example
-    ```ts
-    import { defineComponent, useMeta, computed } from '@nuxtjs/composition-api'
+ ```ts
+ import { defineComponent, useMeta, computed } from '@nuxtjs/composition-api'
 
-    export default defineComponent({
+ export default defineComponent({
       head: {},
       setup() {
         const { title } = useMeta()
         title.value = 'My page'
       })
     })
-    ```
+ ```
  * @param init Whatever defaults you want to set for `head` properties.
  */
 export const useMeta = <T extends MetaInfo>(init?: T | (() => T)) => {
-  const vm = getCurrentInstance()
+  const vm = getCurrentInstance() as ReturnType<typeof getCurrentInstance> & {
+    _computedHead?: ComputedHead
+    _metaRefs?: MetaRefs
+  }
   if (!vm) throw new Error('useMeta must be called within a component.')
 
-  if (!('_head' in vm.$options))
+  if (!('head' in vm.$options))
     throw new Error(
       'In order to enable `useMeta`, please make sure you include `head: {}` within your component definition, and you are using the `defineComponent` exported from @nuxtjs/composition-api.'
     )
 
-  const { _head, _computedHead } = vm.$options as {
-    _head: ReactiveHead
-    _computedHead: Array<Ref<MetaInfo>>
+  function refreshMeta() {
+    vm!.$meta().refresh()
   }
 
-  assign(_head, createEmptyMeta())
-  if (init instanceof Function) {
-    _computedHead.push(computed(init))
-  } else {
-    assign<MetaInfo>(_head, init || {})
+  if (!vm._computedHead) {
+    const metaRefs = reactive(createEmptyMeta())
+    vm._computedHead = [metaRefs]
+    vm._metaRefs = toRefs(metaRefs) as MetaRefs
+
+    if (process.client) {
+      watch(Object.values(vm._metaRefs), refreshMeta, { immediate: true })
+    }
   }
 
-  const refs = toRefs(_head) as ToRefs<ReturnType<typeof createEmptyMeta> & T>
+  if (init) {
+    const initRef = init instanceof Function ? computed(init) : ref(init)
+    vm._computedHead.push(initRef)
 
-  if (process.client) {
-    watch(Object.values(refs), () => vm.$meta().refresh(), { immediate: true })
+    if (process.client) {
+      watch(initRef, refreshMeta, { immediate: true })
+    }
   }
 
-  return refs
+  return vm._metaRefs
 }


### PR DESCRIPTION
Trying to fix https://github.com/nuxt-community/composition-api/issues/267

I removed the properties declared on the `$options` and declared them directly on the instance.