### PR TITLE
fix: added `ssrContext` fallback for `useFetch`

### DIFF
--- a/test/e2e/hooks.ts
+++ b/test/e2e/hooks.ts
@@ -9,6 +9,7 @@ const assertions = async () => {
   await expectOnPage('global setup was run 1 times on client')
   await expectOnPage('globally injected value was received')
   await expectOnPage('globally injected config from context was injected')
+  await expectOnPage('global fetch was run 1 times on server')
 }
 
 test('Runs plugin on server side page', async () => {

--- a/test/fixture/pages/hooks.vue
+++ b/test/fixture/pages/hooks.vue
@@ -19,20 +19,25 @@
         globally injected config from context was
         {{ globalConfig.globalInject }}
       </code>
+      <br />
+      <code>
+        global fetch was {{ ranFetch ? 'run' : 'not run' }} {{ ranFetch }} times
+        on server
+      </code>
     </p>
   </blockquote>
 </template>
 
 <script>
 import { defineComponent, inject } from '@nuxtjs/composition-api'
-import { ran, ranSsr } from '../plugins/global'
+import { ran, ranSsr, ranFetch } from '../plugins/global'
 
 export default defineComponent({
   setup() {
     const globalInject = inject('globalKey', false)
     const globalConfig = inject('globalContext', {})
 
-    return { globalInject, ran, ranSsr, globalConfig }
+    return { globalInject, ran, ranSsr, ranFetch, globalConfig }
   },
 })
 </script>

--- a/test/fixture/plugins/global.js
+++ b/test/fixture/plugins/global.js
@@ -4,17 +4,23 @@ import {
   ref,
   ssrRef,
   useContext,
+  useFetch,
 } from '@nuxtjs/composition-api'
 
 export const ranSsr = ssrRef(0)
 export const ran = ref(0)
+export const ranFetch = ssrRef(0)
 
 export default () => {
   ran.value = 0
+  ranFetch.value = 0
   if (process.server) ranSsr.value = 0
 
   onGlobalSetup(() => {
     const { $config } = useContext()
+    useFetch(async () => {
+      ranFetch.value++
+    })
 
     ran.value++
     if (process.server) ranSsr.value++
@@ -25,6 +31,7 @@ export default () => {
     return {
       ran,
       ranSsr,
+      ranFetch,
     }
   })
 }


### PR DESCRIPTION
When using `useFetch` inside an `onGlobalSetup` callback, it fails due to null access on some objects.

This PR adds a couple of fallbacks for the `ssrContext` and `$vnode` objects on the `vm` that triggered the fetch and please correct me on my assumptions:

- use `vm.context.ssrContext` as a fallback for `vm.$ssrContext` which to me seems to have the exact shape with the proper data
- avoid adding `fetchKey` attr on possibly non-existent `$vnode` as I don't think it makes sense for the global setup to have a fetch key on the root element

I have followed some of the tests and added a test case for this, please let me know if any changes can be made or if this PR isn't suitable.

closes #275 