### PR TITLE
feat: separate plugin into server-side & client-side

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,9 +32,16 @@ const compositionApiModule: Module<any> = function () {
     corejsPolyfill = undefined
   }
 
-  const { dst: pluginDst } = this.addTemplate({
+  const { dst: pluginServerDst } = this.addTemplate({
     src: resolve(libRoot, 'templates', 'plugin.js'),
-    fileName: join('composition-api', 'plugin.js'),
+    fileName: join('composition-api', 'plugin.server.js'),
+    mode: 'server',
+  })
+
+  const { dst: pluginClientDst } = this.addTemplate({
+    src: resolve(libRoot, 'templates', 'plugin.js'),
+    fileName: join('composition-api', 'plugin.client.js'),
+    mode: 'client',
     options: {
       corejsPolyfill,
     },
@@ -105,7 +112,8 @@ const compositionApiModule: Module<any> = function () {
   })
 
   this.options.plugins = this.options.plugins || []
-  this.options.plugins.unshift(resolve(this.options.buildDir || '', pluginDst))
+  this.options.plugins.unshift(resolve(this.options.buildDir || '', pluginClientDst))
+  this.options.plugins.unshift(resolve(this.options.buildDir || '', pluginServerDst))
   if (
     !(this.nuxt.options.buildModules || []).includes('@nuxtjs/pwa') &&
     !this.nuxt.options.modules.includes('@nuxtjs/pwa')

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,16 +32,9 @@ const compositionApiModule: Module<any> = function () {
     corejsPolyfill = undefined
   }
 
-  const { dst: pluginServerDst } = this.addTemplate({
+  const { dst: pluginDst } = this.addTemplate({
     src: resolve(libRoot, 'templates', 'plugin.js'),
-    fileName: join('composition-api', 'plugin.server.js'),
-    mode: 'server',
-  })
-
-  const { dst: pluginClientDst } = this.addTemplate({
-    src: resolve(libRoot, 'templates', 'plugin.js'),
-    fileName: join('composition-api', 'plugin.client.js'),
-    mode: 'client',
+    fileName: join('composition-api', 'plugin.js'),
     options: {
       corejsPolyfill,
     },
@@ -112,8 +105,7 @@ const compositionApiModule: Module<any> = function () {
   })
 
   this.options.plugins = this.options.plugins || []
-  this.options.plugins.unshift(resolve(this.options.buildDir || '', pluginClientDst))
-  this.options.plugins.unshift(resolve(this.options.buildDir || '', pluginServerDst))
+  this.options.plugins.unshift(resolve(this.options.buildDir || '', pluginDst))
   if (
     !(this.nuxt.options.buildModules || []).includes('@nuxtjs/pwa') &&
     !this.nuxt.options.modules.includes('@nuxtjs/pwa')

--- a/templates/plugin.js
+++ b/templates/plugin.js
@@ -1,10 +1,12 @@
-<% if (options.corejsPolyfill === '3') { %>
-// Necessary polyfill for Composition API support for IE11
-import 'core-js/features/reflect/own-keys'
-<% } else if (options.corejsPolyfill === '2') { %>
-// Necessary polyfill for Composition API support for IE11
-import 'core-js/modules/es6.reflect.own-keys'
-<% } %>
+if (process.client) {
+  <% if (options.corejsPolyfill === '3') { %>
+  // Necessary polyfill for Composition API support for IE11
+  require('core-js/features/reflect/own-keys')
+  <% } else if (options.corejsPolyfill === '2') { %>
+  // Necessary polyfill for Composition API support for IE11
+  require('core-js/modules/es6.reflect.own-keys')
+  <% } %>
+}
 
 import { globalPlugin } from '@nuxtjs/composition-api'
 


### PR DESCRIPTION
The current setting will create a plugin that imports `core-js` for both server-side and  client-side
```
// Necessary polyfill for Composition API support for IE11
import 'core-js/features/reflect/own-keys'
``` 
However, server-side is no need to use `core-js`

Therefore this PR separate plugin into server-side & client-side in order to get rid of `core-js` from the server-side