### PR TITLE
fix: set `useFetch` delay to 0 by default

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -234,7 +234,7 @@ export const useFetch = (callback: Fetch) => {
   }
 
   vm._fetchDelay =
-    typeof vm.$options.fetchDelay === 'number' ? vm.$options.fetchDelay : 200
+    typeof vm.$options.fetchDelay === 'number' ? vm.$options.fetchDelay : 10
 
   vm.$fetch = callFetches.bind(vm)
 

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -234,7 +234,7 @@ export const useFetch = (callback: Fetch) => {
   }
 
   vm._fetchDelay =
-    typeof vm.$options.fetchDelay === 'number' ? vm.$options.fetchDelay : 10
+    typeof vm.$options.fetchDelay === 'number' ? vm.$options.fetchDelay : 0
 
   vm.$fetch = callFetches.bind(vm)
 

--- a/test/e2e/fetch.ts
+++ b/test/e2e/fetch.ts
@@ -40,6 +40,16 @@ test('Refetches with $fetch', async t => {
   await expectOnPage('loading email')
 })
 
+test('TTFB is lower than 100ms', async t => {
+  await navigateTo('/')
+  const ttfbRegex = /TTFB: (\d+)ms/
+  const selector = Selector('*').withText(new RegExp(ttfbRegex, 'i'))
+  const text = await selector.innerText
+  const [, msString] = /TTFB: (\d+)ms/.exec(text)!
+  const ms = Number(msString)
+  t.expect(ms).lte(100)
+})
+
 test("Doesn't overwrite methods and getters", async () => {
   await navigateTo('/')
   await expectOnPage('computed')

--- a/test/e2e/fetch.ts
+++ b/test/e2e/fetch.ts
@@ -41,7 +41,7 @@ test('Refetches with $fetch', async t => {
 })
 
 test('TTFB is lower than 100ms', async t => {
-  await navigateTo('/')
+  await navigateTo('/ttfb')
   const ttfbRegex = /TTFB: (\d+)ms/
   const selector = await Selector('*').withText(new RegExp(ttfbRegex, 'i'))
   const text = await selector.innerText

--- a/test/e2e/fetch.ts
+++ b/test/e2e/fetch.ts
@@ -43,11 +43,11 @@ test('Refetches with $fetch', async t => {
 test('TTFB is lower than 100ms', async t => {
   await navigateTo('/')
   const ttfbRegex = /TTFB: (\d+)ms/
-  const selector = Selector('*').withText(new RegExp(ttfbRegex, 'i'))
+  const selector = await Selector('*').withText(new RegExp(ttfbRegex, 'i'))
   const text = await selector.innerText
   const [, msString] = /TTFB: (\d+)ms/.exec(text)!
   const ms = Number(msString)
-  t.expect(ms).lte(100)
+  await t.expect(ms).lte(100)
 })
 
 test("Doesn't overwrite methods and getters", async () => {

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -41,6 +41,9 @@
       </li>
       <li><nuxt-link to="/meta">meta</nuxt-link></li>
     </ul>
+    <div>
+      TTFB: {{ ttfb }}ms
+    </div>
   </main>
 </template>
 
@@ -50,6 +53,7 @@ import {
   ref,
   computed,
   useFetch,
+  onMounted
 } from '@nuxtjs/composition-api'
 import ChildComp from '../components/comp.vue'
 
@@ -73,11 +77,17 @@ export default defineComponent({
       if (process.client) email.value = await fetcher('long@load.com', 2000)
     })
 
+    const ttfb = ref(-1)
+    onMounted(() => {
+      ttfb.value = globalThis.performance.getEntriesByType('navigation')[0].responseStart
+    })
+
     return {
       name,
       email,
       computedProp,
       myFunction,
+      ttfb
     }
   },
 })

--- a/test/fixture/pages/ttfb.vue
+++ b/test/fixture/pages/ttfb.vue
@@ -1,0 +1,33 @@
+<template>
+  <main>
+    TTFB: {{ ttfb }}ms
+  </main>
+</template>
+
+<script>
+import {
+  defineComponent,
+  ref,
+  computed,
+  useFetch,
+  onMounted
+} from '@nuxtjs/composition-api'
+import ChildComp from '../components/comp.vue'
+
+import { fetcher } from '../utils'
+
+export default defineComponent({
+  setup() {
+    useFetch(() => {})
+
+    const ttfb = ref(-1)
+    onMounted(() => {
+      ttfb.value = globalThis.performance.getEntriesByType('navigation')[0].responseStart
+    })
+
+    return {
+      ttfb
+    }
+  },
+})
+</script>


### PR DESCRIPTION
Fixes: #359 

Sets the default `useFetch` delay to `0` 😋