### PR TITLE
fix: transpile `@vue/composition-api`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,10 +108,11 @@ const compositionApiModule: Module<any> = function compositionApiModule() {
   }
 
   this.options.build.transpile = this.options.build.transpile || []
-  this.options.build.transpile.push(
-    /@nuxtjs[\\/]composition-api/,
-    /@vue[\\/]composition-api/
-  )
+  this.options.build.transpile.push(/@nuxtjs[\\/]composition-api/)
+
+  if (!this.nuxt.options.dev) {
+    this.options.build.transpile.push(/@vue[\\/]composition-api/)
+  }
 
   const actualPresets = this.options.build.babel.presets
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,10 @@ const compositionApiModule: Module<any> = function compositionApiModule() {
   }
 
   this.options.build.transpile = this.options.build.transpile || []
-  this.options.build.transpile.push(/@nuxtjs[\\/]composition-api/)
+  this.options.build.transpile.push(
+    /@nuxtjs[\\/]composition-api/,
+    /@vue[\\/]composition-api/
+  )
 
   const actualPresets = this.options.build.babel.presets
 

--- a/test/unit/ssr-ref.spec.ts
+++ b/test/unit/ssr-ref.spec.ts
@@ -4,42 +4,6 @@
 import { ssrRef, globalPlugin } from '../../lib/entrypoint'
 import * as cAPI from '@vue/composition-api'
 
-jest.setTimeout(60000)
-
-import { setup, get } from '@nuxtjs/module-test-utils'
-import config from '../fixture/nuxt.config'
-
-let nuxt
-
-describe('ssrRef', () => {
-  beforeAll(async () => {
-    nuxt = (await setup(config)).nuxt
-  }, 60000)
-
-  afterAll(async () => {
-    await nuxt.close()
-  })
-
-  test('__NUXT__ contains correct data', async () => {
-    const homePage = await get('/')
-    expect(homePage.includes('"only SSR rendered"')).toBeFalsy()
-    expect(homePage.includes('"runs SSR or client-side"')).toBeFalsy()
-
-    const ssrRefPage = await get('/ssr-ref')
-    expect(ssrRefPage).toContain('"only SSR rendered"')
-    expect(ssrRefPage).toContain('"runs SSR or client-side"')
-
-    const noSetupPage = await get('/no-setup')
-    expect(noSetupPage).toContain('"prefetched async"')
-    expect(noSetupPage).toContain('"SSR overwritten"')
-    expect(noSetupPage.includes('"unchanged"')).toBeFalsy()
-
-    const rerenderedHomePage = await get('/')
-    expect(rerenderedHomePage.includes('"only SSR rendered"')).toBeFalsy()
-    expect(rerenderedHomePage.includes('"runs SSR or client-side"')).toBeFalsy()
-  })
-})
-
 describe('ssrRef reactivity', () => {
   let ssrContext: Record<string, any>
 


### PR DESCRIPTION
* means @nuxtjs/composition-api can truly be in `devDependencies`