### PR TITLE
feat: initial implementation of new composables (wip)

### DIFF
--- a/src/composables/globals.ts
+++ b/src/composables/globals.ts
@@ -6,6 +6,12 @@ export const globalContext = '<%= options.globalContext %>'.includes('options')
   ? '__NUXT__'
   : ('<%= options.globalContext %>' as '__NUXT__')
 
+export const globalNuxtReady = '<%= options.globalNuxtReady %>'.includes(
+  'options'
+)
+  ? 'onNuxtReady'
+  : ('<%= options.globalNuxtReady %>' as 'onNuxtReady')
+
 export const isFullStatic = '<%= options.isFullStatic %>'.includes('options')
   ? false
   : JSON.parse('<%= options.isFullStatic %>')

--- a/src/composables/hooks.ts
+++ b/src/composables/hooks.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from '@nuxt/types'
 import type { SetupContext } from '@vue/composition-api'
+import { globalNuxt, globalNuxtReady } from './globals'
 import { getHeadOptions } from './meta'
 
 import { reqRefs } from './req-ref'
@@ -47,6 +48,12 @@ export const globalPlugin: Plugin = context => {
   if (process.server) {
     reqRefs.forEach(reset => reset())
     setSSRContext(context.app)
+  }
+
+  if (process.client) {
+    ;(window as any)[globalNuxtReady](() => {
+      ;(window[globalNuxt] as any).__isReady = true
+    })
   }
 
   const { setup } = context.app

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -8,3 +8,5 @@ export { ssrRef, shallowSsrRef, setSSRContext, ssrPromise } from './ssr-ref'
 export { useStatic } from './static'
 export * from './defineHelpers'
 export * from './wrappers'
+
+export * from './next'

--- a/src/composables/next/asyncData.ts
+++ b/src/composables/next/asyncData.ts
@@ -1,0 +1,138 @@
+import {
+  onMounted,
+  onUnmounted,
+  Ref,
+  ref,
+  set,
+  watch,
+  UnwrapRef,
+} from '@vue/composition-api'
+
+import { getCurrentInstance } from '../utils'
+
+import { ensureReactive, useData } from './data'
+import { Nuxt, useNuxt } from './nuxt'
+import { isInitialLoad } from './compat'
+
+export type AsyncDataFn<T> = (ctx?: Nuxt) => Promise<T>
+
+export interface AsyncDataOptions {
+  server?: boolean
+  defer?: boolean
+}
+
+export interface AsyncDataObj<T> {
+  data: UnwrapRef<T>
+  pending: Ref<boolean>
+  refresh: () => Promise<void>
+  error?: any
+}
+
+export function useAsyncData(defaults?: AsyncDataOptions) {
+  const nuxt = useNuxt()
+  const vm = getCurrentInstance()
+
+  const data = useData(nuxt, vm)
+  let dataRef = 1
+
+  const onMountedCbs: Array<() => Promise<void>> = []
+
+  if (process.client) {
+    onMounted(() => {
+      onMountedCbs.forEach(cb => cb())
+      onMountedCbs.splice(0, onMountedCbs.length)
+      onMountedCbs.push = cb => {
+        cb()
+        return 0
+      }
+    })
+
+    onUnmounted(() => onMountedCbs.splice(0, onMountedCbs.length))
+  }
+
+  return async function asyncData<T = Record<string, any>>(
+    handler: AsyncDataFn<T>,
+    options?: AsyncDataOptions
+  ): Promise<AsyncDataObj<T>> {
+    if (typeof handler !== 'function') {
+      throw new TypeError('asyncData handler must be a function')
+    }
+    options = {
+      server: true,
+      defer: false,
+      ...defaults,
+      ...options,
+    }
+
+    const key = String(dataRef++)
+    const pending = ref(true)
+
+    const datastore = ensureReactive(data, key)
+
+    const fetch = async () => {
+      pending.value = true
+      const _handler = handler(nuxt)
+
+      if (_handler instanceof Promise) {
+        // Let user resolve if request is promise
+        // TODO: handle error
+        const result = await _handler
+
+        console.log('ran fetch', result)
+
+        for (const _key in result) {
+          set(datastore, _key, result[_key])
+        }
+
+        pending.value = false
+      } else {
+        // Invalid request
+        throw new TypeError('Invalid asyncData handler: ' + _handler)
+      }
+    }
+
+    const clientOnly = options.server === false
+
+    // Client side
+    if (process.client) {
+      const isHydrating = isInitialLoad()
+      // 1. Hydration (server: true): no fetch
+      if (isHydrating && options.server) {
+        pending.value = false
+      }
+      // 2. Initial load (server: false): fetch on mounted
+      if (isHydrating && !options.server) {
+        // Fetch on mounted (initial load or deferred fetch)
+        onMountedCbs.push(fetch)
+      } else if (!isHydrating) {
+        if (options.defer) {
+          // 3. Navigation (defer: true): fetch on mounted
+          onMountedCbs.push(fetch)
+        } else {
+          // 4. Navigation (defer: false): await fetch
+          await fetch()
+        }
+      }
+      // Watch handler
+      watch(handler.bind(null, nuxt), fetch)
+    }
+
+    // Server side
+    if (process.server && !clientOnly) {
+      await fetch()
+    }
+
+    return {
+      data: datastore,
+      pending,
+      refresh: fetch,
+    }
+  }
+}
+
+export function asyncData<T = Record<string, any>>(
+  handler: AsyncDataFn<T>,
+  options?: AsyncDataOptions
+): Promise<AsyncDataObj<T>> {
+  return useAsyncData()(handler, options)
+}

--- a/src/composables/next/asyncData.ts
+++ b/src/composables/next/asyncData.ts
@@ -12,7 +12,7 @@ import { getCurrentInstance } from '../utils'
 
 import { ensureReactive, useData } from './data'
 import { Nuxt, useNuxt } from './nuxt'
-import { isInitialLoad } from './compat'
+import { isInitialLoad, isSsrHydration } from './compat'
 
 export type AsyncDataFn<T> = (ctx?: Nuxt) => Promise<T>
 
@@ -78,8 +78,6 @@ export function useAsyncData(defaults?: AsyncDataOptions) {
         // TODO: handle error
         const result = await _handler
 
-        console.log('ran fetch', result)
-
         for (const _key in result) {
           set(datastore, _key, result[_key])
         }
@@ -95,7 +93,7 @@ export function useAsyncData(defaults?: AsyncDataOptions) {
 
     // Client side
     if (process.client) {
-      const isHydrating = isInitialLoad()
+      const isHydrating = isInitialLoad() || isSsrHydration(vm)
       // 1. Hydration (server: true): no fetch
       if (isHydrating && options.server) {
         pending.value = false

--- a/src/composables/next/compat/index.ts
+++ b/src/composables/next/compat/index.ts
@@ -1,0 +1,5 @@
+import { globalNuxt } from '../../globals'
+
+export function isInitialLoad() {
+  return process.client && !(window[globalNuxt] as any).__isReady
+}

--- a/src/composables/next/compat/index.ts
+++ b/src/composables/next/compat/index.ts
@@ -1,4 +1,8 @@
 import { globalNuxt } from '../../globals'
+import { getCurrentInstance } from '../../utils'
+
+export const isSsrHydration = (vm = getCurrentInstance()) =>
+  !!(vm?.$vnode?.elm as any)?.dataset?.ssrRef
 
 export function isInitialLoad() {
   return process.client && !(window[globalNuxt] as any).__isReady

--- a/src/composables/next/data.ts
+++ b/src/composables/next/data.ts
@@ -1,0 +1,61 @@
+import { isReactive, reactive, UnwrapRef } from '@vue/composition-api'
+
+import { globalContext } from '../globals'
+import { getCurrentInstance } from '../utils'
+
+import { useNuxt } from './nuxt'
+
+export function ensureReactive<
+  T extends Record<string, any>,
+  K extends keyof T
+>(data: T, key: K): UnwrapRef<T[K]> {
+  if (!isReactive(data[key])) {
+    data[key] = reactive(data[key] || ({} as T[K]))
+  }
+  return data[key]
+}
+
+/**
+ * Returns a unique string suitable for syncing data between server and client.
+ * @param nuxt (optional) A Nuxt instance
+ * @param vm (optional) A Vue component - by default it will use the current instance
+ */
+export function useSSRRef(nuxt = useNuxt(), vm = getCurrentInstance()): string {
+  if (!vm) throw new Error('This must be called within a setup function.')
+
+  // Server
+  if (process.server) {
+    if (!vm.$vnode.data) vm.$vnode.data = {}
+    const attrs = (vm.$vnode.data.attrs = vm.$vnode.data.attrs || {})
+
+    if (!attrs['data-ssr-ref']) {
+      nuxt._refCtr = nuxt._refCtr || 1
+      attrs['data-ssr-ref'] = String(nuxt._refCtr++)
+    }
+    return attrs['data-ssr-ref']
+  }
+
+  // Client
+  return (
+    (vm.$vnode.elm as any)?.dataset?.ssrRef || String(Math.random())
+  ) /* TODO: unique value for multiple calls */
+}
+
+/**
+ * Allows accessing reactive data that can be synced between server and client.
+ * @param nuxt (optional) A Nuxt instance
+ * @param vm (optional) A Vue component - by default it will use the current instance
+ */
+export function useData<T = Record<string, any>>(
+  nuxt = useNuxt(),
+  vm = getCurrentInstance()
+): UnwrapRef<T> {
+  const ssrRef = useSSRRef(nuxt, vm)
+
+  const nuxtState =
+    nuxt.context.ssrContext?.nuxt || (window as any)[globalContext]
+
+  nuxtState.data = nuxtState.data || {}
+
+  return ensureReactive(nuxtState.data, ssrRef)
+}

--- a/src/composables/next/index.ts
+++ b/src/composables/next/index.ts
@@ -1,0 +1,4 @@
+export { useAsyncData, asyncData } from './asyncData'
+export { useData } from './data'
+export { useNuxt } from './nuxt'
+export { withAsyncSetup } from './setup'

--- a/src/composables/next/nuxt.ts
+++ b/src/composables/next/nuxt.ts
@@ -1,0 +1,37 @@
+import { globalNuxt } from '../globals'
+import { getCurrentInstance } from '../utils'
+
+export type Nuxt = any
+
+let currentNuxtInstance: Nuxt | null
+
+export const setNuxtInstance = (nuxt: Nuxt | null) => {
+  currentNuxtInstance = nuxt
+}
+
+/**
+ * Ensures that the setup function passed in has access to the Nuxt instance via `useNuxt`.
+ * @param nuxt A Nuxt instance
+ * @param setup The function to call
+ */
+export async function callWithNuxt(nuxt: Nuxt, setup: () => any) {
+  setNuxtInstance(nuxt)
+  const p = setup()
+  setNuxtInstance(null)
+  await p
+}
+
+/**
+ * Returns the current Nuxt instance.
+ */
+export function useNuxt(): Nuxt {
+  const vm = getCurrentInstance()
+
+  if (!vm) {
+    if (!currentNuxtInstance) throw new Error('nuxt instance unavailable')
+
+    return currentNuxtInstance
+  }
+
+  return vm[globalNuxt]
+}

--- a/src/composables/next/setup.ts
+++ b/src/composables/next/setup.ts
@@ -1,0 +1,66 @@
+import { defineComponent, onServerPrefetch, ref } from '@vue/composition-api'
+import { getCurrentInstance } from '../utils'
+import { isInitialLoad } from './compat'
+
+export const withAsyncSetup: typeof defineComponent = function withAsyncSetup(
+  options: any
+) {
+  const { components, data, setup } = options
+
+  const Suspense = defineComponent({
+    props: {
+      tag: {
+        type: String,
+        default: 'div',
+      },
+    },
+    data: () => ({
+      data: null,
+    }),
+    render(h) {
+      // hack to link reactivity
+      this.data = this.$parent.$data.$setup.value
+      if (process.client && isInitialLoad()) {
+        // bypassing render on initial load
+        return h(this.tag as 'div', { key: 'ssr' })
+      }
+      if (this.$parent.$data.$setup.value && this.$scopedSlots.default) {
+        return h(
+          this.tag as 'div',
+          this.$scopedSlots.default(this.$parent.$data.$setup.value)
+        )
+      }
+      return h(this.tag as 'div', this.$scopedSlots.fallback?.({}))
+    },
+  })
+
+  return {
+    ...options,
+    components: {
+      ...components,
+      Suspense,
+    },
+    data() {
+      return {
+        ...(data?.() || {}),
+        // This way we benefit from automatic unwrapping to mimic normal template behaviour
+        $setup: ref(null),
+      }
+    },
+    setup() {
+      const vm = getCurrentInstance()
+
+      const promise = setup?.()
+
+      if (process.server) {
+        onServerPrefetch(() =>
+          promise.then((r: any) => (vm!.$data.$setup.value = r))
+        )
+      } else {
+        promise
+          .then((r: any) => (vm!.$data.$setup.value = r))
+          .catch(console.error)
+      }
+    },
+  }
+}

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -26,7 +26,9 @@ const compositionApiModule: Module<never> = function compositionApiModule() {
   // Register entrypoint (where all user-facing content consumed within vite/webpack is located)
 
   const { staticPath } = prepareUseStatic.call(this)
-  const { globalContext, globalNuxt } = getNuxtGlobals.call(this)
+  const { globalContext, globalNuxt, globalNuxtReady } = getNuxtGlobals.call(
+    this
+  )
 
   const routerBase = withTrailingSlash(nuxtOptions.router.base)
   const publicPath = withTrailingSlash(nuxtOptions.build.publicPath)
@@ -40,6 +42,7 @@ const compositionApiModule: Module<never> = function compositionApiModule() {
     // Throughout
     globalContext,
     globalNuxt,
+    globalNuxtReady,
   })
 
   nuxtOptions.alias['@nuxtjs/composition-api'] = entryFile

--- a/src/module/utils.ts
+++ b/src/module/utils.ts
@@ -59,8 +59,13 @@ export function getNuxtGlobals(this: ModuleThis) {
     ((globalName: string) => `__${globalName.toUpperCase()}__`)
   const globalNuxtFactory =
     nuxtOptions.globals.nuxt || ((globalName: string) => `$${globalName}`)
+  const globalNuxtReadyFactory =
+    nuxtOptions.globals.readyCallback ||
+    ((globalName: string) =>
+      `on${globalName[0].toUpperCase() + globalName.slice(1)}Ready`)
   const globalContext = globalContextFactory(globalName)
   const globalNuxt = globalNuxtFactory(globalName)
+  const globalNuxtReady = globalNuxtReadyFactory(globalName)
 
-  return { globalContext, globalNuxt }
+  return { globalContext, globalNuxt, globalNuxtReady }
 }

--- a/test/e2e/asyncdata.ts
+++ b/test/e2e/asyncdata.ts
@@ -1,0 +1,40 @@
+import { Selector } from 'testcafe'
+import {
+  navigateTo,
+  expectOnPage,
+  expectPathnameToBe,
+  expectNotOnPage,
+} from './helpers'
+
+// eslint-disable-next-line
+fixture`asyncdata`
+
+test('Shows fetched data on ssr-loaded page', async t => {
+  await navigateTo('/asyncdata')
+  await expectOnPage('name-Full Name')
+  await expectOnPage('component-Component data')
+})
+
+test('Shows fetched data on client-loaded page', async t => {
+  await navigateTo('/')
+  await t.click(Selector('a').withText('asyncdata'))
+  await expectPathnameToBe('/asyncdata')
+  await expectOnPage('name-Full Name')
+  await expectOnPage('component-Component data')
+})
+
+test('Shows loading state', async t => {
+  await navigateTo('/')
+  await t.click(Selector('a').withText('asyncdata'))
+  await expectPathnameToBe('/asyncdata')
+  await t.wait(4000)
+  await expectOnPage('long@load.com')
+  await expectNotOnPage('loading email')
+})
+
+test('Refetches with refresh', async t => {
+  await navigateTo('/asyncdata')
+  await expectNotOnPage('loading email')
+  await t.click(Selector('button').withText('Refetch'))
+  await expectOnPage('loading email')
+})

--- a/test/fixture/components/asyncdata.vue
+++ b/test/fixture/components/asyncdata.vue
@@ -1,0 +1,31 @@
+<template>
+  <Suspense #default="{ val, pending }">
+    <div>component-{{ val.val }}</div>
+    <button @click="val.val = String(Math.random())">Randomise</button>
+  </Suspense>
+</template>
+
+<script>
+import { withAsyncSetup, asyncData } from '@nuxtjs/composition-api'
+
+export function fetcher(result, time = 100) {
+  return new Promise(resolve => {
+    return setTimeout(() => {
+      resolve(result)
+    }, time)
+  })
+}
+
+export default withAsyncSetup({
+  async setup() {
+    const { data: val, pending } = await asyncData(() =>
+      fetcher({ val: 'Component data' })
+    )
+
+    return {
+      val,
+      pending,
+    }
+  },
+})
+</script>

--- a/test/fixture/pages/asyncdata.vue
+++ b/test/fixture/pages/asyncdata.vue
@@ -1,0 +1,55 @@
+<template>
+  <Suspense #default="{ email, name, refresh, pending }">
+    <div>
+      <p>
+        <button @click="refresh">Refetch</button>
+        <button @click="name.name = String(Math.random())">Randomise</button>
+      </p>
+      <blockquote>
+        <p>
+          <code>name-{{ name.name }}</code>
+        </p>
+        <p>
+          <code>
+            email-{{ email.email }}
+            <br />
+            <span v-if="pending"> loading email </span>
+          </code>
+        </p>
+        <child-comp />
+      </blockquote>
+    </div>
+  </Suspense>
+</template>
+
+<script>
+import {
+  useAsyncData,
+  withAsyncSetup,
+} from '@nuxtjs/composition-api'
+
+import ChildComp from '~/components/asyncdata.vue'
+
+import { fetcher } from '../utils'
+
+export default withAsyncSetup({
+  components: {
+    ChildComp,
+  },
+  async setup() {
+    const asyncData = useAsyncData()
+    const { data: name } = await asyncData(() => fetcher({ name: 'Full Name' }))
+    const { data: email, refresh, pending } = await asyncData(
+      () => fetcher({ email: 'long@load.com' }, 2000),
+      { defer: true }
+    )
+
+    return {
+      name,
+      email,
+      pending,
+      refresh,
+    }
+  },
+})
+</script>

--- a/test/fixture/pages/asyncsetup.vue
+++ b/test/fixture/pages/asyncsetup.vue
@@ -1,13 +1,11 @@
 <template>
   <Suspense>
     <template #default="{ name, test }">
-      <div>
-        Some data:
-        <blockquote>
-          {{ name }}
-        </blockquote>
-        {{ test }}
-      </div>
+      Some data:
+      <blockquote>
+        {{ name }}
+      </blockquote>
+      {{ test }}
     </template>
     <template #fallback> Loading via async setup ... </template>
   </Suspense>

--- a/test/fixture/pages/asyncsetup.vue
+++ b/test/fixture/pages/asyncsetup.vue
@@ -1,0 +1,31 @@
+<template>
+  <Suspense>
+    <template #default="{ name, test }">
+      <div>
+        Some data:
+        <blockquote>
+          {{ name }}
+        </blockquote>
+        {{ test }}
+      </div>
+    </template>
+    <template #fallback> Loading via async setup ... </template>
+  </Suspense>
+</template>
+
+<script>
+import { withAsyncSetup, ref } from '@nuxtjs/composition-api'
+
+import { fetcher } from '../utils'
+
+export default withAsyncSetup({
+  async setup() {
+    const val = await fetcher({ name: 'Full Name' }, 500)
+
+    return {
+      ...val,
+      test: ref('thing'),
+    }
+  },
+})
+</script>

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -41,6 +41,8 @@
       </li>
       <li><nuxt-link to="/meta">meta</nuxt-link></li>
       <li><nuxt-link to="/wrappers">wrappers</nuxt-link></li>
+      <li><nuxt-link to="/asyncdata">asyncdata</nuxt-link></li>
+      <li><nuxt-link to="/asyncsetup">asyncsetup</nuxt-link></li>
     </ul>
     <div>TTFB: {{ ttfb }}ms</div>
   </main>


### PR DESCRIPTION
Some new composables :tada:

**TODO**
- [x] fix unneeded fetch calls for `asyncData` on client-side 

---

### `useNuxt`

### `useData`

### `asyncData` and `useAsyncData`

#### Notes
* using `asyncData` with `defer: false` doesn't defer page navigation. Instead, it just blocks the component render until that async fetch has taken place
* if you want to make multiple calls to `asyncData` you will need first to call `useAsyncData` to get a configured method, for example
   ```ts
   import { useAsyncData, withAsyncSetup } from '@nuxtjs/composition-api'
   
   export default withAsyncSetup({
     async setup() {
       const asyncData = useAsyncData()
       const { data: name } = await asyncData(() => fetch('https://test.com/api'))
       const { data: email } = await asyncData(() => fetch('https://test.com/api'))
       return { name, email }
     }
   }
   ```

### `withAsyncSetup`
Just like `defineComponent`, but supports an `async setup()` block. It registers a `<Suspense>` component that receives the result of the async setup via a scoped slot with support for fallback content.
#### Example 1
```html
<template>
  <Suspense>
    <template #default="{ name, data }">
      Some data from {{ name }}:
      <blockquote>
        {{ JSON.stringify(data) }}
      </blockquote>
    </template>
    <template #fallback> Loading via async setup ... </template>
  </Suspense>
  <!-- or alternatively -->
  <Suspense #default="{ name, data }">
    Some data from {{ name }}:
    <blockquote>
      {{ JSON.stringify(data) }}
    </blockquote>
  </Suspense>
</template>

<script>
import { withAsyncSetup } from '@nuxtjs/composition-api'

export default withAsyncSetup({
  async setup() {
    const data = await fetch('https://test.com/api').then(r => r.json())

    return {
      data,
      name: 'test'
    }
  },
})
</script>
``` 

#### Notes
* as with Vue3, lifecycle methods can only be used before the first async call in `setup()`
* unlike Vue 3, async setup + `<Suspense>` cannot be used across multiple components