### PR TITLE
Update Nuxt Composition Api Module Docs

### DIFF
--- a/docs/content/en/getting-started/setup.md
+++ b/docs/content/en/getting-started/setup.md
@@ -31,7 +31,7 @@ version: 0.161
    ```js[nuxt.config.js]
    {
      buildModules: [
-       '@nuxtjs/composition-api/module'
+       '@nuxtjs/composition-api'
      ]
    }
    ```


### PR DESCRIPTION
When adding to the nuxt config build modules it should be `@nuxtjs/composition-api` not `@nuxtjs/composition-api/module` Hopefully I can save another dev 10 mins of work with this change ;)