### PR TITLE
Remove duplicate content in gotchas.md

### DIFF
--- a/docs/content/en/getting-started/gotchas.md
+++ b/docs/content/en/getting-started/gotchas.md
@@ -1,13 +1,11 @@
 ---
 title: Gotchas
-description: 'There are a couple of key points to remember when using the composition API.'
+description: 'There are a couple of points that you should be aware of when using `@nuxtjs/composition-api`.'
 category: Getting started
 fullscreen: True
 position: 3
 version: 0.133
 ---
-
-There are a couple of points that you should be aware of when using `@nuxtjs/composition-api`.
 
 ## **'Keyed' functions**
 


### PR DESCRIPTION
Without these changes, the page says basically the same thing twice. Alternatively, we could remove the description and use the content.