### PR TITLE
fix(runtime): export default from register entry

### DIFF
--- a/src/runtime/templates/register.js
+++ b/src/runtime/templates/register.js
@@ -3,3 +3,4 @@ import CompositionApi from '@vue/composition-api'
 
 Vue.use(CompositionApi)
 
+export default {}


### PR DESCRIPTION
As a result of https://github.com/nuxt-community/composition-api/commit/9d4165a3511ffeb2cf1e0584a303565b41b0f968, this line is being added to middleware.js

> import $c289ad42 from './composition-api/register.js'

Which fails on vite since `register.js` is not exporting any default.

For a longer run, I HIGHLY recommend avoiding this workaround for ordering and adding register.js to build entry 
