### PR TITLE
feat: hide useMeta warning using a config parameter

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -77,7 +77,7 @@ const compositionApiModule: Module<never> = function compositionApiModule() {
     !nuxtOptions.modules.includes('@nuxtjs/pwa')
   ) {
     nuxtOptions.plugins.push(addResolvedTemplate.call(this, 'meta.mjs'))
-  } else if (nuxtOptions.dev) {
+  } else if (nuxtOptions.dev && !nuxtOptions?.pwa?.hideCompositionApiWarning) {
     console.warn(
       'useMeta is not supported in onGlobalSetup as @nuxtjs/pwa detected.\nSee https://github.com/nuxt-community/composition-api/issues/307'
     )


### PR DESCRIPTION
Hey 🙂

As mentionned here: https://github.com/nuxtlabs/docus/issues/304, we would like to be able to remove the useMeta warning for Docus.

This PR introduces this possibility by adding `pwa.hideCompositionApiWarning` configuration parameter.

As @nuxtjs/composition-api does not have a config object into nuxt.config.{js|ts}, I added this under the `pwa` one.

As this is probably not the best approach, feel free to change where this belongs!

Thank you 🙏