### PR TITLE
docs: remove `--dev` flag in home page snippet

### DIFF
--- a/docs/pages/en/index.md
+++ b/docs/pages/en/index.md
@@ -16,7 +16,7 @@ cta:
   secondary:
 - Open on GitHub
 - https://github.com/nuxt-community/composition-api
-  snippet: yarn add --dev @nuxtjs/composition-api
+  snippet: yarn add @nuxtjs/composition-api
   :::
 
 ::::card-grid{title="What's included?"}


### PR DESCRIPTION
In the snippet tells to install with `--dev` flag, but is required in the builded app