### PR TITLE
docs: remover "2 second interval" rule for ssg

### DIFF
--- a/docs/pages/en/1.getting-started/2.setup.md
+++ b/docs/pages/en/1.getting-started/2.setup.md
@@ -36,18 +36,7 @@ npm install @nuxtjs/composition-api --save
 
    Note that [using `buildModules`](https://nuxtjs.org/api/configuration-modules#-code-buildmodules-code-) requires Nuxt >= 2.9. Just add it to your `modules` if you're on a lower version.
 
-3. **Optional**. Currently [there's an issue with static site generation and async functions](https://github.com/nuxt-community/composition-api/issues/44) which means that you'll need to add time between pages being generated to allow for any async functions to resolve, if you are pre-generating any of your pages:
-
-   ```js[nuxt.config.js]
-   {
-     generate: {
-       // choose to suit your project
-       interval: 2000,
-     }
-   }
-   ```
-
-4. You're good to go!
+3. You're good to go!
 
 :::alert{type="info"}
 


### PR DESCRIPTION
According to https://github.com/nuxt-community/composition-api/issues/44#issuecomment-808558924 this only applies in rare circumstances.

Instead of simply deleting it, maybe we should add it to the `ssrRef` *or* Gotcha doc page? 🤔 