### PR TITLE
fix: resolve to single vue instance

### DIFF
--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -21,6 +21,14 @@ const compositionApiModule: Module<never> = function compositionApiModule() {
   nuxtOptions.build.transpile = nuxtOptions.build.transpile || []
   nuxtOptions.build.transpile.push('@nuxtjs/composition-api', runtimeDir)
 
+  // Define vue resolution to prevent VCA being registered to the wrong Vue instance
+
+  nuxtOptions.alias.vue =
+    nuxtOptions.alias.vue ||
+    (nuxtOptions.dev
+      ? this.nuxt.resolver.resolveModule('vue/dist/vue.common.dev.js')
+      : this.nuxt.resolver.resolveModule('vue/dist/vue.runtime.esm.js'))
+
   // Define @vue/composition-api resolution to prevent using different versions of @vue/composition-api
 
   const capiEntrypoint = '@vue/composition-api/dist/vue-composition-api.esm.js'


### PR DESCRIPTION
This PR aliases vue to a single Vue instance, required when using other libraries that resolve vue differently. Normally this would have just added bytes to the bundle, but because of how the composition API is implemented, it breaks reactivity.

resolves https://github.com/nuxt-community/composition-api/issues/507, resolves https://github.com/nuxt-community/composition-api/issues/521