### PR TITLE
docs: clarify where `$http` is coming from

### DIFF
--- a/docs/pages/en/6.API/1.useAsync.md
+++ b/docs/pages/en/6.API/1.useAsync.md
@@ -7,7 +7,9 @@ You can create reactive values that depend on asynchronous calls with `useAsync`
 
 On the server, this helper will inline the result of the async call in your HTML and automatically inject them into your client code. Much like `asyncData`, it _won't_ re-run these async calls client-side.
 
-However, if the call hasn't been carried out on SSR (such as if you have navigated to the page after initial load), it returns a `null` ref that is filled with the result of the async call when it resolves.
+However, if the call hasn't been carried out on SSR (such as if you have navigated to the page after initial load), it returns a `null` ref that is filled with the result of the async call when it resol
+
+The `$http` here has been taken from the [`@nuxt/http` module](https://http.nuxtjs.org/). In order for this example to work, you need to install it (`yarn add @nuxt/http`/`npm install @nuxt/http`) and add it to your `nuxt.config.js` modules list. 
 
 ```ts
 import { defineComponent, useAsync, useContext } from '@nuxtjs/composition-api'


### PR DESCRIPTION
When I first tried to work with this, I was at a loss as to why the code wasn't running as the Nuxt HTTP module wasn't properly configured to work in my project. So, I have explained where this comes from and how to add the module to prevent other people reading the docs from having the same issue.