### PR TITLE
fix: ssrRef cannot proxyfy constructors

### DIFF
--- a/src/runtime/composables/ssr-ref.ts
+++ b/src/runtime/composables/ssr-ref.ts
@@ -107,7 +107,10 @@ export const ssrRef = <T>(value: T | (() => T), key?: string): Ref<T> => {
         track()
         if (isProxyable(target[prop]))
           return getProxy(track, trigger, target[prop])
-        return Reflect.get(target, prop)
+
+        const value = Reflect.get(target, prop)
+
+        return typeof value === 'function' ? value.bind(target) : value
       },
       set(obj, prop, newVal) {
         const result = Reflect.set(obj, prop, newVal)

--- a/test/unit/__snapshots__/ssr-ref.spec.ts.snap
+++ b/test/unit/__snapshots__/ssr-ref.spec.ts.snap
@@ -11,6 +11,16 @@ Object {
 }
 `;
 
+exports[`ssrRef reactivity ssrRefs react to constructors 1`] = `
+RefImpl {
+  "value": bound Object {
+    "testMap": Map {
+      "john" => "doe",
+    },
+  },
+}
+`;
+
 exports[`ssrRef reactivity ssrRefs react to deep change in array state 1`] = `
 Object {
   "nuxt": Object {

--- a/test/unit/ssr-ref.spec.ts
+++ b/test/unit/ssr-ref.spec.ts
@@ -52,4 +52,13 @@ describe('ssrRef reactivity', () => {
 
     expect(ssrContext).toMatchSnapshot()
   })
+
+  test('ssrRefs react to constructors', async () => {
+    const testMap = new Map()
+    testMap.set('john', 'doe')
+
+    const obj = ssrRef({ testMap }, 'obj')
+
+    expect(obj).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Hello, 

Sometimes when you create more complex SSR refs, that contain instances of a built-in constructor (Map, WeakMap, Promise, etc), it may cause errors due to proxying nested objects:

```
TypeError: Method Map.prototype.entries called on incompatible receiver [object Object]
```


This is a sort of limitation - those constructors keep the state inside of "internal fields" which Proxy cannot intercept by using get/set handlers, so we need to switch calling context of their methods.


