### PR TITLE
chore: add nuxt bridge migration recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ---
 
-**Nuxt Bridge has now been released in beta.** It's strongly recommended to migrate to Nuxt Bridge by following the steps in [the Bridge migration guide](https://v3.nuxtjs.org/getting-started/bridge/). Make sure to read the [specific migration guide](https://v3.nuxtjs.org/getting-started/bridge-composition-api) on how to replace composables from `@nuxtjs/composition-api` with the new Nuxt 3-compatible composables provided by Bridge.
+**Nuxt Bridge has now been released in beta.** It has full composition API support and it's strongly recommended to migrate from `@nuxtjs/composition-api`, if possible, by following the steps in [the Bridge migration guide](https://v3.nuxtjs.org/getting-started/bridge/). Feedback welcome at `https://github.com/nuxt-community/composition-api/discussions/585`.
 
 ---
 

--- a/docs/pages/en/1.getting-started/1.introduction.md
+++ b/docs/pages/en/1.getting-started/1.introduction.md
@@ -6,9 +6,8 @@ description: '@nuxtjs/composition-api provides a way to use the Vue 3 Compositio
 > `@nuxtjs/composition-api` provides a way to use the Vue 3 Composition API in with Nuxt-specific features.
 
 :::alert{type="info"}
-Nuxt Bridge has now been released in beta. It's strongly recommended to migrate _instead_ to Nuxt Bridge by following the steps in [the Bridge migration guide](https://v3.nuxtjs.org/getting-started/bridge/). Make sure to read the [specific migration guide](https://v3.nuxtjs.org/getting-started/bridge-composition-api) on how to replace composables from `@nuxtjs/composition-api` with the new Nuxt 3-compatible composables provided by Bridge.
+**Nuxt Bridge has now been released in beta.** It has full composition API support and it's strongly recommended to use Nuxt Bridge _instead_, if possible, by following the steps in [the Bridge migration guide](https://v3.nuxtjs.org/getting-started/bridge/). Feedback welcome at `https://github.com/nuxt-community/composition-api/discussions/585`.
 :::
-
 
 ## Key features
 

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -148,11 +148,13 @@ const compositionApiModule: Module<never> = function compositionApiModule() {
   // Enable using `script setup`
   this.addModule('unplugin-vue2-script-setup/nuxt')
 
-  this.nuxt.hook('build:done', () => {
-    console.info(
-      "`Nuxt Bridge has now been released in beta.` It has full composition API support and it's strongly recommended to migrate from `@nuxtjs/composition-api`, if possible, by following the steps at `https://v3.nuxtjs.org/getting-started/bridge`. Feedback welcome at `https://github.com/nuxt-community/composition-api/discussions/585`.\n"
-    )
-  })
+  if (!this.nuxt.options.capi?.disableMigrationWarning) {
+    this.nuxt.hook('build:done', () => {
+      console.info(
+        "`Nuxt Bridge has now been released in beta.` It has full composition API support and it's strongly recommended to migrate from `@nuxtjs/composition-api`, if possible, by following the steps at `https://v3.nuxtjs.org/getting-started/bridge`. Feedback welcome at `https://github.com/nuxt-community/composition-api/discussions/585`.\n"
+      )
+    })
+  }
 }
 
 // eslint-disable-next-line
@@ -163,4 +165,3 @@ compositionApiModule.meta = {
 }
 
 export default compositionApiModule
-// export * from './defineHelpers'

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -147,6 +147,12 @@ const compositionApiModule: Module<never> = function compositionApiModule() {
 
   // Enable using `script setup`
   this.addModule('unplugin-vue2-script-setup/nuxt')
+
+  this.nuxt.hook('build:done', () => {
+    console.info(
+      "`Nuxt Bridge has now been released in beta.` It has full composition API support and it's strongly recommended to migrate from `@nuxtjs/composition-api`, if possible, by following the steps at `https://v3.nuxtjs.org/getting-started/bridge`. Feedback welcome at `https://github.com/nuxt-community/composition-api/discussions/585`.\n"
+    )
+  })
 }
 
 // eslint-disable-next-line


### PR DESCRIPTION
This can be disabled with the following options in `nuxt.config`:
```js
export default {
  capi: {
    disableMigrationWarning: true
  }
}
```