### PR TITLE
docs(meta): add note about defineComponent import

### DIFF
--- a/docs/pages/en/2.packages/3.useMeta.md
+++ b/docs/pages/en/2.packages/3.useMeta.md
@@ -5,6 +5,10 @@ description: 'You can define your head and meta properties with the Nuxt Composi
 
 You can interact directly with [head properties](https://nuxtjs.org/api/pages-head/) in `setup` (and within the `onGlobalSetup` method) by means of the `useMeta()` helper.
 
+:::alert
+Make sure that you use `defineComponent` exported from `@nuxtjs/composition-api`, otherwise `useMeta` won't work
+:::
+
 ```ts
 import { defineComponent, useMeta, computed, ref } from '@nuxtjs/composition-api'
 

--- a/docs/pages/en/2.packages/3.useMeta.md
+++ b/docs/pages/en/2.packages/3.useMeta.md
@@ -6,7 +6,7 @@ description: 'You can define your head and meta properties with the Nuxt Composi
 You can interact directly with [head properties](https://nuxtjs.org/api/pages-head/) in `setup` (and within the `onGlobalSetup` method) by means of the `useMeta()` helper.
 
 :::alert
-Make sure that you use `defineComponent` exported from `@nuxtjs/composition-api`, otherwise `useMeta` won't work
+In order to enable `useMeta`, please make sure you include `head: {}` within your component definition, and you are using the `defineComponent` exported from `@nuxtjs/composition-api`.
 :::
 
 ```ts


### PR DESCRIPTION
Add this note so it makes more clear that `defineComponent` from `vue` or `@vue/composition-api` won't work with `useMeta`

Related: https://github.com/nuxt-community/composition-api/issues/651