### PR TITLE
fix: allow returning of falsy values from useAsync

### DIFF
--- a/src/runtime/composables/async.ts
+++ b/src/runtime/composables/async.ts
@@ -38,7 +38,7 @@ export const useAsync = <T>(
   const _ref = isRef(key) ? key : ssrRef<T | null>(null, key)
 
   if (
-    !_ref.value ||
+    _ref.value === null ||
     (process.env.NODE_ENV === 'development' &&
       process.client &&
       window[globalNuxt]?.context.isHMR)


### PR DESCRIPTION
Related to #493

If a falsy value is returned from useAsync, the client will always run the request again.

You could completely allow falsy values by adding a `hasRun` ssrRef but I fear it would pollute the global space.

So, as a compromise, with this change you can avoid having the client re-run a request if you return **any falsy value other than null (and void)**

Edit:
I guess another solution would be to convert the default ref value to an object, something like `{ data: null, hasRun: false }` and maintain the single ssrRef that's already generated currently. But I think the proposed change is simple enough and really has no downsides to current behavior afaik.