### PR TITLE
chore(docs): remove confusing mentions of Vue 3 Composition API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 </a>
 </p>
 
-> `@nuxtjs/composition-api` provides a way to use the Vue 3 Composition API in with Nuxt-specific features.
+> `@nuxtjs/composition-api` provides a way to use the Vue Composition API in with Nuxt-specific features.
 
 ---
 

--- a/docs/pages/en/1.getting-started/1.introduction.md
+++ b/docs/pages/en/1.getting-started/1.introduction.md
@@ -1,9 +1,9 @@
 ---
 title: Introduction
-description: '@nuxtjs/composition-api provides a way to use the Vue 3 Composition API with Nuxt-specific features.'
+description: '@nuxtjs/composition-api provides a way to use the Vue Composition API with Nuxt-specific features.'
 ---
 
-> `@nuxtjs/composition-api` provides a way to use the Vue 3 Composition API in with Nuxt-specific features.
+> `@nuxtjs/composition-api` provides a way to use the Vue Composition API in with Nuxt-specific features.
 
 :::alert{type="info"}
 **Nuxt Bridge has now been released in beta.** It has full composition API support and it's strongly recommended to use Nuxt Bridge _instead_, if possible, by following the steps in [the Bridge migration guide](https://v3.nuxtjs.org/getting-started/bridge/). Feedback welcome at [https://github.com/nuxt-community/composition-api/discussions/585](https://github.com/nuxt-community/composition-api/discussions/585).

--- a/docs/pages/en/index.md
+++ b/docs/pages/en/index.md
@@ -2,7 +2,7 @@
 template: landing
 title: Nuxt Composition API
 description: >-
-  Vue 3 Composition API in Nuxt
+  Vue Composition API in Nuxt 2
 navigation: false
 ---
 
@@ -20,7 +20,7 @@ snippet: yarn add @nuxtjs/composition-api
 :::
 
 ::::card-grid{title="What's included?"}
-:::card{icon="IconVue" title="Vue 3 Composition API"}
+:::card{icon="IconVue" title="Vue Composition API"}
 Get all the Composition API features in Nuxt 2.
 :::
 


### PR DESCRIPTION
"Vue 3 Composition API" is a confusing statement since Vue 2.7 also supports composition API now. So remove "3" from places that say that. Also clarify that this module is for Nuxt 2.