### PR TITLE
fix: remove `@nuxt/vue-app` peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "yorkie": "^2.0.0"
   },
   "peerDependencies": {
-    "@nuxt/vue-app": "^2.15",
     "nuxt": "^2.15",
     "vue": "^2.7.14"
   },


### PR DESCRIPTION
When this peer dependency was added there have actually existed an [explicit import](https://github.com/nuxt-community/composition-api/blob/d94c40eb8b581bd9f1ab888310985966c7126643/src/fetch.ts#L7-L7) that referenced it but it's not the case anymore so this should not be needed.